### PR TITLE
feat(daily-recap): add Morpho daily recap step

### DIFF
--- a/.github/workflows/daily-recap.yml
+++ b/.github/workflows/daily-recap.yml
@@ -59,5 +59,11 @@ jobs:
           PYTHONPATH: script/
           PROD: "True"
 
-
-      
+      - name: Run the Morpho daily recap bot
+        run: |
+          cd ${{ env.DEVOPS_DIR }}
+          python script/tg-bots/morpho-daily/main.py
+        shell: bash
+        env:
+          PYTHONPATH: script/
+          PROD: "True"


### PR DESCRIPTION
## Summary

- Adds a step to `daily-recap.yml` that runs `script/tg-bots/morpho-daily/main.py` after the staking-v2-daily bot
- No new secrets required (Morpho API is public, Telegram key is in constants)

## Depends on

stake-dao/automation-jobs#751

## Test plan

- [ ] Merge automation-jobs PR first