### PR TITLE
perf: speed up bot workflows with uv + reusable template

### DIFF
--- a/.github/workflows/_bot.yml
+++ b/.github/workflows/_bot.yml
@@ -1,0 +1,78 @@
+name: _bot (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      dispatch_id:
+        type: string
+        required: false
+        default: ""
+      scripts:
+        type: string
+        required: true
+        description: Newline-separated python scripts to run from $DEVOPS_DIR
+
+env:
+  DEVOPS_DIR: devops
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "dispatch_id:${{ inputs.dispatch_id || 'manual' }}"
+        if: always()
+        run: echo "Temporal tracking"
+
+      - name: Checkout automation-jobs
+        uses: actions/checkout@v4
+        with:
+          repository: stake-dao/automation-jobs
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          path: ${{ env.DEVOPS_DIR }}
+          ref: main
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: devops/requirements.txt
+
+      - name: Cache venv
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.DEVOPS_DIR }}/.venv
+          key: venv-${{ runner.os }}-py310-${{ hashFiles(format('{0}/requirements.txt', env.DEVOPS_DIR)) }}
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          cd "$DEVOPS_DIR"
+          [ -d .venv ] || uv venv .venv
+          uv pip install -r requirements.txt
+
+      - name: Run bot scripts
+        shell: bash
+        env:
+          PYTHONPATH: script/
+          PROD: "True"
+          WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
+          FRAXTAL_RPC: ${{ secrets.FRAXTAL_RPC }}
+          BSC_RPC: ${{ secrets.BSC_RPC }}
+          FRAXSCAN_API_KEY: ${{ secrets.FRAXSCAN_API_KEY }}
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+          EXPLORER_KEY: ${{ secrets.EXPLORER_KEY }}
+          HASURA_SECRET: ${{ secrets.HASURA_SECRET }}
+        run: |
+          cd "$DEVOPS_DIR"
+          source .venv/bin/activate
+          while IFS= read -r s; do
+            [ -z "$s" ] && continue
+            echo "::group::$s"
+            python "$s"
+            echo "::endgroup::"
+          done <<< "${{ inputs.scripts }}"

--- a/.github/workflows/asdcrv.yml
+++ b/.github/workflows/asdcrv.yml
@@ -9,54 +9,10 @@ on:
         required: false
         default: ""
 
-env:
-  TARGET_DEVOPS_DIR: target-devops
-  DEVOPS_DIR: devops
-  WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
-  FRAXTAL_RPC: ${{ secrets.FRAXTAL_RPC }}
-  BSC_RPC: ${{ secrets.BSC_RPC }}
-  FRAXSCAN_API_KEY: ${{ secrets.FRAXSCAN_API_KEY }}
-  ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-  EXPLORER_KEY: ${{ secrets.EXPLORER_KEY }}
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "dispatch_id:${{ github.event.inputs.dispatch_id || 'manual' }}"
-        if: always()
-        run: echo "Temporal tracking"
-
-      - name: Checkout the tg-bots repo
-        uses: actions/checkout@v4
-        with:
-          repository: stake-dao/automation-jobs
-          token: ${{ secrets.GIT_ACCESS_TOKEN }}
-          path: ${{ env.DEVOPS_DIR }}
-          ref: main
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10.13"
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: pip install -r ${{ env.DEVOPS_DIR }}/requirements.txt
-        shell: bash
-
-      - name: Run the Llamalend asdcrv script
-        run: |
-          cd ${{ env.DEVOPS_DIR }}
-          python script/bots/asdcrv/main.py
-        shell: bash
-        env:
-          PYTHONPATH: script/
-          PROD: "True"
+  run:
+    uses: ./.github/workflows/_bot.yml
+    secrets: inherit
+    with:
+      dispatch_id: ${{ inputs.dispatch_id }}
+      scripts: script/bots/asdcrv/main.py

--- a/.github/workflows/curve-pools.yml
+++ b/.github/workflows/curve-pools.yml
@@ -9,54 +9,10 @@ on:
         required: false
         default: ""
 
-env:
-  TARGET_DEVOPS_DIR: target-devops
-  DEVOPS_DIR: devops
-  WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
-  FRAXTAL_RPC: ${{ secrets.FRAXTAL_RPC }}
-  BSC_RPC: ${{ secrets.BSC_RPC }}
-  FRAXSCAN_API_KEY: ${{ secrets.FRAXSCAN_API_KEY }}
-  ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-  EXPLORER_KEY: ${{ secrets.EXPLORER_KEY }}
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "dispatch_id:${{ github.event.inputs.dispatch_id || 'manual' }}"
-        if: always()
-        run: echo "Temporal tracking"
-
-      - name: Checkout the tg-bots repo
-        uses: actions/checkout@v4
-        with:
-          repository: stake-dao/automation-jobs
-          token: ${{ secrets.GIT_ACCESS_TOKEN }}
-          path: ${{ env.DEVOPS_DIR }}
-          ref: main
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10.13"
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: pip install -r ${{ env.DEVOPS_DIR }}/requirements.txt
-        shell: bash
-
-      - name: Run the lockers script
-        run: |
-          cd ${{ env.DEVOPS_DIR }}
-          python script/bots/curve/pools/main.py
-        shell: bash
-        env:
-          PYTHONPATH: script/
-          PROD: "True"
+  run:
+    uses: ./.github/workflows/_bot.yml
+    secrets: inherit
+    with:
+      dispatch_id: ${{ inputs.dispatch_id }}
+      scripts: script/bots/curve/pools/main.py

--- a/.github/workflows/daily-recap.yml
+++ b/.github/workflows/daily-recap.yml
@@ -9,69 +9,13 @@ on:
         required: false
         default: ""
 
-env:
-  TARGET_DEVOPS_DIR: target-devops
-  DEVOPS_DIR: devops
-  WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
-  FRAXTAL_RPC: ${{ secrets.FRAXTAL_RPC }}
-  BSC_RPC: ${{ secrets.BSC_RPC }}
-  
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "dispatch_id:${{ github.event.inputs.dispatch_id || 'manual' }}"
-        if: always()
-        run: echo "Temporal tracking"
-
-      - name: Checkout the tg-bots repo
-        uses: actions/checkout@v4
-        with:
-          repository: stake-dao/automation-jobs
-          token: ${{ secrets.GIT_ACCESS_TOKEN }}
-          path: ${{ env.DEVOPS_DIR }}
-          ref: main
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10.13"
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: pip install -r ${{ env.DEVOPS_DIR }}/requirements.txt
-        shell: bash
-
-      - name: Run the LL daily recap bot
-        run: |
-          cd ${{ env.DEVOPS_DIR }}
-          python script/bots/daily/lockers/main.py
-        shell: bash
-        env:
-          PYTHONPATH: script/
-          PROD: "True"
-
-      - name: Run the Strategies daily recap bot
-        run: |
-          cd ${{ env.DEVOPS_DIR }}
-          python script/bots/staking_v2_daily/main.py
-        shell: bash
-        env:
-          PYTHONPATH: script/
-          PROD: "True"
-
-      - name: Run the Morpho daily recap bot
-        run: |
-          cd ${{ env.DEVOPS_DIR }}
-          python script/bots/morpho_daily/main.py
-        shell: bash
-        env:
-          PYTHONPATH: script/
-          PROD: "True"
+  run:
+    uses: ./.github/workflows/_bot.yml
+    secrets: inherit
+    with:
+      dispatch_id: ${{ inputs.dispatch_id }}
+      scripts: |
+        script/bots/daily/lockers/main.py
+        script/bots/staking_v2_daily/main.py
+        script/bots/morpho_daily/main.py

--- a/.github/workflows/morpho.yml
+++ b/.github/workflows/morpho.yml
@@ -9,54 +9,10 @@ on:
         required: false
         default: ""
 
-env:
-  TARGET_DEVOPS_DIR: target-devops
-  DEVOPS_DIR: devops
-  WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
-  FRAXTAL_RPC: ${{ secrets.FRAXTAL_RPC }}
-  BSC_RPC: ${{ secrets.BSC_RPC }}
-  FRAXSCAN_API_KEY: ${{ secrets.FRAXSCAN_API_KEY }}
-  ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-  EXPLORER_KEY: ${{ secrets.EXPLORER_KEY }}
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "dispatch_id:${{ github.event.inputs.dispatch_id || 'manual' }}"
-        if: always()
-        run: echo "Temporal tracking"
-
-      - name: Checkout the tg-bots repo
-        uses: actions/checkout@v4
-        with:
-          repository: stake-dao/automation-jobs
-          token: ${{ secrets.GIT_ACCESS_TOKEN }}
-          path: ${{ env.DEVOPS_DIR }}
-          ref: main
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10.13"
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: pip install -r ${{ env.DEVOPS_DIR }}/requirements.txt
-        shell: bash
-
-      - name: Run the Morpho Stake DAO script
-        run: |
-          cd ${{ env.DEVOPS_DIR }}
-          python script/bots/morpho/main.py
-        shell: bash
-        env:
-          PYTHONPATH: script/
-          PROD: "True"
+  run:
+    uses: ./.github/workflows/_bot.yml
+    secrets: inherit
+    with:
+      dispatch_id: ${{ inputs.dispatch_id }}
+      scripts: script/bots/morpho/main.py

--- a/.github/workflows/onlyboost_v2.yml
+++ b/.github/workflows/onlyboost_v2.yml
@@ -9,55 +9,10 @@ on:
         required: false
         default: ""
 
-env:
-  TARGET_DEVOPS_DIR: target-devops
-  DEVOPS_DIR: devops
-  WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
-  FRAXTAL_RPC: ${{ secrets.FRAXTAL_RPC }}
-  BSC_RPC: ${{ secrets.BSC_RPC }}
-  FRAXSCAN_API_KEY: ${{ secrets.FRAXSCAN_API_KEY }}
-  ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-  EXPLORER_KEY: ${{ secrets.EXPLORER_KEY }}
-  HASURA_SECRET: ${{ secrets.HASURA_SECRET }}
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "dispatch_id:${{ github.event.inputs.dispatch_id || 'manual' }}"
-        if: always()
-        run: echo "Temporal tracking"
-
-      - name: Checkout the tg-bots repo
-        uses: actions/checkout@v4
-        with:
-          repository: stake-dao/automation-jobs
-          token: ${{ secrets.GIT_ACCESS_TOKEN }}
-          path: ${{ env.DEVOPS_DIR }}
-          ref: main
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10.13"
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: pip install -r ${{ env.DEVOPS_DIR }}/requirements.txt
-        shell: bash
-
-      - name: Run the onlyboost-v2 script
-        run: |
-          cd ${{ env.DEVOPS_DIR }}
-          python script/bots/onlyboost_v2/main.py
-        shell: bash
-        env:
-          PYTHONPATH: script/
-          PROD: "True"
+  run:
+    uses: ./.github/workflows/_bot.yml
+    secrets: inherit
+    with:
+      dispatch_id: ${{ inputs.dispatch_id }}
+      scripts: script/bots/onlyboost_v2/main.py

--- a/.github/workflows/vesdt.yml
+++ b/.github/workflows/vesdt.yml
@@ -9,54 +9,10 @@ on:
         required: false
         default: ""
 
-env:
-  TARGET_DEVOPS_DIR: target-devops
-  DEVOPS_DIR: devops
-  WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
-  FRAXTAL_RPC: ${{ secrets.FRAXTAL_RPC }}
-  BSC_RPC: ${{ secrets.BSC_RPC }}
-  FRAXSCAN_API_KEY: ${{ secrets.FRAXSCAN_API_KEY }}
-  ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-  EXPLORER_KEY: ${{ secrets.EXPLORER_KEY }}
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "dispatch_id:${{ github.event.inputs.dispatch_id || 'manual' }}"
-        if: always()
-        run: echo "Temporal tracking"
-
-      - name: Checkout the tg-bots repo
-        uses: actions/checkout@v4
-        with:
-          repository: stake-dao/automation-jobs
-          token: ${{ secrets.GIT_ACCESS_TOKEN }}
-          path: ${{ env.DEVOPS_DIR }}
-          ref: main
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10.13"
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: pip install -r ${{ env.DEVOPS_DIR }}/requirements.txt
-        shell: bash
-
-      - name: Run the veSDT script
-        run: |
-          cd ${{ env.DEVOPS_DIR }}
-          python script/bots/vesdt/main.py
-        shell: bash
-        env:
-          PYTHONPATH: script/
-          PROD: "True"
+  run:
+    uses: ./.github/workflows/_bot.yml
+    secrets: inherit
+    with:
+      dispatch_id: ${{ inputs.dispatch_id }}
+      scripts: script/bots/vesdt/main.py

--- a/.github/workflows/votemarket-incentives.yml
+++ b/.github/workflows/votemarket-incentives.yml
@@ -9,49 +9,10 @@ on:
         required: false
         default: ""
 
-env:
-  DEVOPS_DIR: devops
-  WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
-  EXPLORER_KEY: ${{ secrets.EXPLORER_KEY }}
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "dispatch_id:${{ github.event.inputs.dispatch_id || 'manual' }}"
-        if: always()
-        run: echo "Temporal tracking"
-
-      - name: Checkout the automation-jobs repo
-        uses: actions/checkout@v4
-        with:
-          repository: stake-dao/automation-jobs
-          token: ${{ secrets.GIT_ACCESS_TOKEN }}
-          path: ${{ env.DEVOPS_DIR }}
-          ref: main
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10.13"
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: pip install -r ${{ env.DEVOPS_DIR }}/requirements.txt
-        shell: bash
-
-      - name: Run the Votemarket Direct Incentives bot
-        run: |
-          cd ${{ env.DEVOPS_DIR }}
-          python script/bots/votemarket_incentives/main.py
-        shell: bash
-        env:
-          PYTHONPATH: script/
-          PROD: "True"
+  run:
+    uses: ./.github/workflows/_bot.yml
+    secrets: inherit
+    with:
+      dispatch_id: ${{ inputs.dispatch_id }}
+      scripts: script/bots/votemarket_incentives/main.py

--- a/.github/workflows/votemarket-v2.yml
+++ b/.github/workflows/votemarket-v2.yml
@@ -9,51 +9,10 @@ on:
         required: false
         default: ""
 
-env:
-  TARGET_DEVOPS_DIR: target-devops
-  DEVOPS_DIR: devops
-  WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
-  FRAXTAL_RPC: ${{ secrets.FRAXTAL_RPC }}
-  BSC_RPC: ${{ secrets.BSC_RPC }}
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "dispatch_id:${{ github.event.inputs.dispatch_id || 'manual' }}"
-        if: always()
-        run: echo "Temporal tracking"
-
-      - name: Checkout the tg-bots repo
-        uses: actions/checkout@v4
-        with:
-          repository: stake-dao/automation-jobs
-          token: ${{ secrets.GIT_ACCESS_TOKEN }}
-          path: ${{ env.DEVOPS_DIR }}
-          ref: main
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10.13"
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: pip install -r ${{ env.DEVOPS_DIR }}/requirements.txt
-        shell: bash
-
-      - name: Run VM V2 script
-        run: |
-          cd ${{ env.DEVOPS_DIR }}
-          python script/bots/votemarket/v2/votemarket.py
-        shell: bash
-        env:
-          PYTHONPATH: script/
-          PROD: "True"
+  run:
+    uses: ./.github/workflows/_bot.yml
+    secrets: inherit
+    with:
+      dispatch_id: ${{ inputs.dispatch_id }}
+      scripts: script/bots/votemarket/v2/votemarket.py


### PR DESCRIPTION
## Summary

- Extracted shared bot pipeline into `.github/workflows/_bot.yml` (reusable via `workflow_call`)
- Switched `pip` → `uv` for 5–10× faster dependency installs (`astral-sh/setup-uv@v5` with built-in cache)
- Added a venv cache keyed on `requirements.txt` hash so re-installs skip unpack on a hit
- Loosened `python-version` to `"3.10"` (uses runner toolcache) instead of the exact `"3.10.13"` download
- Collapsed 8 near-identical callers into thin dispatch shims (~408 lines → ~129)
- `dispatch_id` input + echo step preserved (required by Maestro / Temporal run matching per `maestro/README.md:195-210` and `packages/core/src/activities/github.ts:105-122`)

## Next step (separate PR, not here)

Installing the fat `automation-jobs/requirements.txt` (146 deps incl. `eth-ape`, 6 ape plugins, `ape-roll` git dep) is still the dominant cost. A follow-up refactor in `automation-jobs` to lazy-import `ape` out of `shared/utils/globals.py` unlocks a slim `requirements-bots.txt` for this repo. Plan saved locally.

## Test plan

- [ ] Manually dispatch one workflow (e.g. `asdcrv.yml`) from the Actions tab with a fake `dispatch_id` — confirm the `dispatch_id:<id>` step appears and the bot runs end-to-end
- [ ] Let the orchestrator fire its scheduled dispatch → confirm Maestro matches the run via `dispatch_id`
- [ ] Confirm the venv cache gets populated on first run and reused on second run (check action logs: `Cache restored from key: venv-Linux-py310-<hash>`)
- [ ] Verify `daily-recap.yml` runs all three scripts sequentially
- [ ] Compare total run time before/after for one bot to confirm the speed-up