### PR TITLE
feat(workflows): vlSDT + veSDT migration bot dispatchers

### DIFF
--- a/.github/workflows/vesdt-migration.yml
+++ b/.github/workflows/vesdt-migration.yml
@@ -1,0 +1,62 @@
+name: Bot veSDT Migration
+
+on:
+  workflow_dispatch:
+    inputs:
+      dispatch_id:
+        type: string
+        description: "Unique ID for Temporal tracking"
+        required: false
+        default: ""
+
+env:
+  TARGET_DEVOPS_DIR: target-devops
+  DEVOPS_DIR: devops
+  WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
+  FRAXTAL_RPC: ${{ secrets.FRAXTAL_RPC }}
+  BSC_RPC: ${{ secrets.BSC_RPC }}
+  FRAXSCAN_API_KEY: ${{ secrets.FRAXSCAN_API_KEY }}
+  ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+  EXPLORER_KEY: ${{ secrets.EXPLORER_KEY }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "dispatch_id:${{ github.event.inputs.dispatch_id || 'manual' }}"
+        if: always()
+        run: echo "Temporal tracking"
+
+      - name: Checkout the tg-bots repo
+        uses: actions/checkout@v4
+        with:
+          repository: stake-dao/automation-jobs
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          path: ${{ env.DEVOPS_DIR }}
+          ref: main
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10.13"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: pip install -r ${{ env.DEVOPS_DIR }}/requirements.txt
+        shell: bash
+
+      - name: Run the veSDT migration script
+        run: |
+          cd ${{ env.DEVOPS_DIR }}
+          python script/bots/vesdt_migration/main.py
+        shell: bash
+        env:
+          PYTHONPATH: script/
+          PROD: "True"

--- a/.github/workflows/vlsdt.yml
+++ b/.github/workflows/vlsdt.yml
@@ -1,0 +1,62 @@
+name: Bot vlSDT
+
+on:
+  workflow_dispatch:
+    inputs:
+      dispatch_id:
+        type: string
+        description: "Unique ID for Temporal tracking"
+        required: false
+        default: ""
+
+env:
+  TARGET_DEVOPS_DIR: target-devops
+  DEVOPS_DIR: devops
+  WEB3_ALCHEMY_API_KEY: ${{ secrets.WEB3_ALCHEMY_API_KEY }}
+  FRAXTAL_RPC: ${{ secrets.FRAXTAL_RPC }}
+  BSC_RPC: ${{ secrets.BSC_RPC }}
+  FRAXSCAN_API_KEY: ${{ secrets.FRAXSCAN_API_KEY }}
+  ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+  EXPLORER_KEY: ${{ secrets.EXPLORER_KEY }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "dispatch_id:${{ github.event.inputs.dispatch_id || 'manual' }}"
+        if: always()
+        run: echo "Temporal tracking"
+
+      - name: Checkout the tg-bots repo
+        uses: actions/checkout@v4
+        with:
+          repository: stake-dao/automation-jobs
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          path: ${{ env.DEVOPS_DIR }}
+          ref: main
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10.13"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: pip install -r ${{ env.DEVOPS_DIR }}/requirements.txt
+        shell: bash
+
+      - name: Run the vlSDT script
+        run: |
+          cd ${{ env.DEVOPS_DIR }}
+          python script/bots/vlsdt/main.py
+        shell: bash
+        env:
+          PYTHONPATH: script/
+          PROD: "True"


### PR DESCRIPTION
## Summary
Add GitHub Actions dispatchers for the two new bots from automation-jobs PR [#780](https://github.com/stake-dao/automation-jobs/pull/780):

- `vlsdt.yml` → runs `script/bots/vlsdt/main.py` (vlSDT activity)
- `vesdt-migration.yml` → runs `script/bots/vesdt_migration/main.py` (veSDT → vlSDT migration alert)

Mirrors `vesdt.yml`: `workflow_dispatch` only (Temporal-triggered), checkout `automation-jobs@main`, Python 3.10.13, pip cache.

## Test plan
- [ ] Merge automation-jobs#780 first so the referenced scripts exist on `main`
- [ ] Manual `workflow_dispatch` of each new workflow to confirm it runs end-to-end
- [ ] Confirm Temporal can dispatch both workflows by name